### PR TITLE
fix(tools): fix docker-compose package required

### DIFF
--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -27,7 +27,7 @@ RUN yes | pacman --sync --refresh \
         p7zip \
         python \
         python-netaddr \
-        terraform \
-        python-pip
+        python-pip \
+        terraform
 
 RUN pip install docker-compose

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -27,4 +27,7 @@ RUN yes | pacman --sync --refresh \
         p7zip \
         python \
         python-netaddr \
-        terraform
+        terraform \
+        python-pip
+
+RUN pip install docker-compose


### PR DESCRIPTION
On starting PXE server, we encountered the following error:

```
TASK [pxe-server : Start ephemeral PXE server] *****************************************************************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ModuleNotFoundError: No module named 'requests'
fatal: [localhost]: FAILED! => {
    "changed": false
}

MSG:

Failed to import the required Python library (Docker SDK for Python: docker above 5.0.0 (Python >= 3.6) or docker before 5.0.0 (Python 2.7) or docker-py (Python 2.6)) on lmaiarch's Python /usr/bin/python. Please read the module documentation and install it in the appropriate location. If the required library is installed, but Ansible is using the wrong Python interpreter, please consult the documentation on ansible_python_interpreter, for example via `pip install docker` (Python >= 3.6) or `pip install docker==4.4.4` (Python 2.7) or `pip install docker-py` (Python 2.6). The error was: No module named 'requests'

PLAY RECAP *****************************************************************************************************************************************************
localhost                  : ok=6    changed=5    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0
```

Solve by adding pip and install docker-compose via pip.