### PR TITLE
fix(metal): fix deprecated kernel parameter

### DIFF
--- a/metal/roles/pxe-server/templates/grub.cfg.j2
+++ b/metal/roles/pxe-server/templates/grub.cfg.j2
@@ -3,6 +3,6 @@ set timeout=1
 menuentry '{{ iso_url | basename | splitext | first }} (PXE)' {
     linux vmlinuz \
         ip=dhcp \
-        ks=http://{{ ansible_default_ipv4.address }}/init-config/${net_default_mac}.ks
+        inst.ks=http://{{ ansible_default_ipv4.address }}/init-config/${net_default_mac}.ks
     initrd initrd.img
 }


### PR DESCRIPTION
`ks` flag is deprecated in the nearby future. Small update to avoid that.