### PR TITLE
chore: improve monitoring setting

### DIFF
--- a/bootstrap/argocd/values.yaml
+++ b/bootstrap/argocd/values.yaml
@@ -54,37 +54,27 @@ argo-cd:
       enabled: true
       serviceMonitor:
         enabled: true
-        additionalLabels:
-          release: "kube-prometheus-stack"
 
   controller:
     metrics:
       enabled: true
       serviceMonitor:
         enabled: true
-        additionalLabels:
-          release: "kube-prometheus-stack"
 
   repoServer:
     metrics:
       enabled: true
       serviceMonitor:
         enabled: true
-        additionalLabels:
-          release: "kube-prometheus-stack"
   
   redis:
     metrics:
       enabled: true
       serviceMonitor:
         enabled: true
-        additionalLabels:
-          release: "kube-prometheus-stack"
   
   dex:
     metrics:
       enabled: true
       serviceMonitor:
         enabled: true
-        additionalLabels:
-          release: "kube-prometheus-stack"

--- a/system/cert-manager/values.yaml
+++ b/system/cert-manager/values.yaml
@@ -4,9 +4,6 @@ cert-manager:
     enabled: true
     servicemonitor:
       enabled: true
-      labels:
-        release: kube-prometheus-stack
 
 issuer:
   email: khuedoan98@gmail.com
-

--- a/system/cloudflared/values.yaml
+++ b/system/cloudflared/values.yaml
@@ -16,7 +16,3 @@ cloudflared:
     enabled: true
     metricsEndpoints:
       - port: http
-
-    # additional labels for the PodMonitor
-    extraLabels:
-      release: kube-prometheus-stack

--- a/system/external-dns/values.yaml
+++ b/system/external-dns/values.yaml
@@ -8,9 +8,6 @@ external-dns:
           key: value
   extraArgs:
     - --annotation-filter=external-dns.alpha.kubernetes.io/exclude notin (true)
-  
-  labels:
-    release: kube-prometheus-stack
 
   metrics:
     enabled: true

--- a/system/ingress-nginx/values.yaml
+++ b/system/ingress-nginx/values.yaml
@@ -8,8 +8,6 @@ ingress-nginx:
 
       serviceMonitor:
         enabled: true
-        additionalLabels:
-          release: kube-prometheus-stack
         
   tcp:
     22: gitea/gitea-ssh:22

--- a/system/loki/values.yaml
+++ b/system/loki/values.yaml
@@ -1,7 +1,5 @@
 loki:
   serviceMonitor:
     enabled: true
-    additionalLabels:
-      release: kube-prometheus-stack
     annotations: {}
     # scrapeTimeout: 10s

--- a/system/longhorn-system/templates/servicemonitor.yaml
+++ b/system/longhorn-system/templates/servicemonitor.yaml
@@ -4,8 +4,6 @@ kind: ServiceMonitor
 metadata:
   name: longhorn
   namespace: longhorn-system
-  labels:
-    release: kube-prometheus-stack
 spec:
   selector:
     matchLabels:

--- a/system/monitoring-system/values.yaml
+++ b/system/monitoring-system/values.yaml
@@ -15,3 +15,19 @@ kube-prometheus-stack:
       - name: Loki
         type: loki
         url: http://loki.loki:3100
+
+  prometheus:
+    prometheusSpec:
+      serviceMonitorSelectorNilUsesHelmValues: false
+      serviceMonitorNamespaceSelector: {}
+      podMonitorSelectorNilUsesHelmValues: false
+      podMonitorNamespaceSelector: {}
+
+      storageSpec:
+        volumeClaimTemplate:
+          spec:
+            storageClassName: longhorn
+            accessModes: ["ReadWriteOnce"]
+            resources:
+              requests:
+                storage: 20Gi


### PR DESCRIPTION
## Intents
- Enable Prometheus to scrape all namespaces without the `release: kube-prometheus-stack` selector
- Set persistent storage with longhorn
- Clean up the redundant extra label `release: kube-prometheus-stack` from all service/pod monitors