### PR TITLE
Tools: Install missing openssh

### DIFF
--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -23,14 +23,14 @@ RUN yes | pacman --sync --refresh \
         libisoburn \
         make \
         mdbook \
+        openssh \
         p7zip \
         python \
         python-kubernetes \
         python-netaddr \
         python-pip \
         sudo \
-        terraform \
-        openssh
+        terraform
 
 # TODO https://github.com/ansible-collections/community.docker/issues/216
 RUN pip install docker-compose

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -29,7 +29,8 @@ RUN yes | pacman --sync --refresh \
         python-netaddr \
         python-pip \
         sudo \
-        terraform
+        terraform \
+        openssh
 
 # TODO https://github.com/ansible-collections/community.docker/issues/216
 RUN pip install docker-compose


### PR DESCRIPTION
I was missing `ssh-keygen` within the docker environment, even though `openssh` is a core package for arch.
Installing it provided the missing binary.