### PR TITLE
fix(metal/dhcp): use IP lease range based on network CIDR

### DIFF
--- a/metal/roles/pxe_server/templates/dhcpd.conf.j2
+++ b/metal/roles/pxe_server/templates/dhcpd.conf.j2
@@ -7,7 +7,7 @@ option architecture-type code 93 = unsigned integer 16;
 
 subnet {{ ansible_default_ipv4.network }} netmask {{ ansible_default_ipv4.netmask }} {
     option routers {{ ansible_default_ipv4.gateway }};
-    range {{ ansible_default_ipv4.gateway | ansible.netcommon.ipmath(1) }} {{ ansible_default_ipv4.broadcast | ansible.netcommon.ipmath(-1) }};
+    range {{ ansible_default_ipv4.network | ansible.netcommon.ipmath(1) }} {{ ansible_default_ipv4.broadcast | ansible.netcommon.ipmath(-1) }};
 
     class "pxeclients" {
         match if substring (option vendor-class-identifier, 0, 9) = "PXEClient";


### PR DESCRIPTION
BUG: sometime, the default gateway ip is not always .1, thus not stable to use as lease ip range for dhcp.
For example: if your default gaateway IP is 192.168.1.253, then your dhcp lease range is 192.168.1.254-192.168.1.254, and the pxe boot process won't work