### PR TITLE
Add note regarding terraform cloud execution mode

### DIFF
--- a/external/README.md
+++ b/external/README.md
@@ -62,6 +62,8 @@ Apply Terraform (you will be prompted to login to Terraform Cloud and enter API 
 make
 ```
 
+Note: If you are using Terraform Cloud, ensure you set "Execution Mode" as "Local" in your workspace settings as Terraform Cloud won't be able to access your homelab cluster.
+
 ## Alternatives
 
 - Terraform Cloud: any other [Terraform backends](https://www.terraform.io/language/settings/backends)

--- a/external/README.md
+++ b/external/README.md
@@ -25,7 +25,13 @@ This layer will:
 
 ### Create Terraform workspace
 
-TODO
+Terraform is stateful, which means it needs somewhere to store it's state. The Terraform Cloud is one option for a state backend with a generous free tier perfect for a homelab.
+
+1. Sign up for a [Terraform Cloud](https://cloud.hashicorp.com/products/terraform)
+2. Create a workspace named `homelab-external`, this is the workspace where your homelab state will be stored.
+3. Change the "Execution Mode" from "Remote" to "Local". This will ensure your local machine, which can access your lab, is the one executing the terraform plan rather than the cloud runners.
+
+If you decide to use a different terraform backend, you'll need to edit the [external/versions.tf](./versions.tf) file as required.
 
 ### Create Cloudflare API token
 
@@ -61,8 +67,6 @@ Apply Terraform (you will be prompted to login to Terraform Cloud and enter API 
 ```sh
 make
 ```
-
-Note: If you are using Terraform Cloud, ensure you set "Execution Mode" as "Local" in your workspace settings as Terraform Cloud won't be able to access your homelab cluster.
 
 ## Alternatives
 


### PR DESCRIPTION
When configuring a workspace in Terraform Cloud, the execution mode defaults to "Remote". This is problematic for two reasons:
1. The secrets / keys entered on the tfvars ansible step will be ignored, but the error doesn't make it immediately obvious that it's because the remote runner doesn't get the local `terraform.tfvars` file so the problem is slightly hidden.
1. We use local files that are not in the terraform plan directory. This could also result in a similar issue above I think as it won't be able to locate some of the requested files.
2. The remote (cloud) runner won't be able to access the kube cluster running on the internal network anyway, so any plan application will fail.

This tripped me up for a couple moments around trying to consume the api keys until I realised that what it had defaulted to. Hopefully this note will help prevent that issue for some others.