### PR TITLE
fix(configure): replace domain in terraform files

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -47,6 +47,7 @@ def main() -> None:
             "bootstrap",
             "platform",
             "system",
+            "external",
         ]
     )
 


### PR DESCRIPTION
I'm adding the external folder to the replace in configure.py to replace the domain value in cloudflare.tf
for those configuring their dns with cloudflare and cloudflare tunnels

Adding scripts folder might be a good idea to replace it in argocd login script.