### PR TITLE
fix(configure): missing comma in folders path list

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -42,7 +42,7 @@ def main() -> None:
         pattern=default_domain,
         replacement=domain,
         paths=[
-            ".tekton"
+            ".tekton",
             "apps",
             "bootstrap",
             "platform",


### PR DESCRIPTION
Was causing the find and replace to fail because it was looking for .tektonapps folder instead of .tekton and .apps