### PR TITLE
Update Vagrantfile

### DIFF
--- a/metal/Vagrantfile
+++ b/metal/Vagrantfile
@@ -11,6 +11,7 @@ disk_size = "128GB"
 
 Vagrant.configure("2") do |config|
   config.vm.box = "rockylinux/8"
+  config.vm.box_version = "4.0.0"
 
   inventory['metal']['children'].each do |group, properties|
     properties['hosts'].each do |host, host_vars|


### PR DESCRIPTION
New version of box 5.0.0 released 2 days a go getting 404 on vagrant cloud. So there is need to specify older version 4.0.0 witch is accessible.