### PR TITLE
chore(external-secrets): upgrade to 0.5.6

### DIFF
--- a/platform/external-secrets/Chart.yaml
+++ b/platform/external-secrets/Chart.yaml
@@ -3,5 +3,5 @@ name: external-secrets
 version: 0.0.0
 dependencies:
   - name: external-secrets
-    version: 0.5.2
+    version: 0.5.6
     repository: https://charts.external-secrets.io


### PR DESCRIPTION
0.5.2 had an issue where if the value was not found in vault there would be a panic from a nil pointer reference. This was fixed in 0.5.3 but the latest is 0.5.6 so I tested that and all seems to work well.

I've been running on a single node, not sure if that has caused the issue to be more prominent but as I've been tweaking my own setup based on this repo I've had this happen a couple of times on a fresh re-build of the lab.