### PR TITLE
MetalLB chart location change

### DIFF
--- a/system/metallb-system/Chart.yaml
+++ b/system/metallb-system/Chart.yaml
@@ -4,4 +4,4 @@ version: 0.0.0
 dependencies:
   - name: metallb
     version: 0.12.1
-    repository: https://metallb.github.io/metallb
+    repository: https://charts.bitnami.com/bitnami


### PR DESCRIPTION
See: https://github.com/helm/charts/tree/master/stable/metallb (old chart location is deprecated and no longer available)