### PR TITLE
refactor(metal): migrate to Fedora 36 for newer packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,11 @@ They can't capture all the project's features, but they are sufficient to get a 
         <td>Synchronizes exposed Kubernetes Services and Ingresses with DNS providers</td>
     </tr>
     <tr>
+        <td><img width="32" src="https://upload.wikimedia.org/wikipedia/commons/thumb/3/3f/Fedora_logo.svg/267px-Fedora_logo.svg.png"></td>
+        <td><a href="https://getfedora.org/en/server">Fedora Server</a></td>
+        <td>Base OS for Kubernetes nodes</td>
+    </tr>
+    <tr>
         <td><img width="32" src="https://upload.wikimedia.org/wikipedia/commons/b/bb/Gitea_Logo.svg"></td>
         <td><a href="https://gitea.com">Gitea</a></td>
         <td>Self-hosted Git service</td>
@@ -174,11 +179,6 @@ They can't capture all the project's features, but they are sufficient to get a 
         <td><img width="32" src="https://docs.renovatebot.com/assets/images/logo.png"></td>
         <td><a href="https://www.whitesourcesoftware.com/free-developer-tools/renovate">Renovate</a></td>
         <td>Automatically update dependencies</td>
-    </tr>
-    <tr>
-        <td><img width="32" src="https://avatars.githubusercontent.com/u/75713131?s=200&v=4"></td>
-        <td><a href="https://rockylinux.org">Rocky Linux</a></td>
-        <td>Base OS for Kubernetes nodes</td>
     </tr>
     <tr>
         <td><img width="32" src="https://avatars.githubusercontent.com/u/47602533?s=200&v=4"></td>

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -54,7 +54,7 @@ From now on, ArgoCD will do the rest:
 ```mermaid
 flowchart TD
   subgraph metal[./metal]
-    pxe[PXE Server] -.-> linux[Rocky Linux] --> k3s
+    pxe[PXE Server] -.-> linux[Fedora Server] --> k3s
   end
 
   subgraph bootstrap[./bootstrap]

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -26,4 +26,4 @@ To view PXE server (includes DHCP, TFTP and HTTP server) logs:
 - Check if the operating system ISO file is mounted
 - Check the controller's firewall config
 - Check PXE server Docker logs
-- Check if the servers are booting to the correct OS (Rocky Linux installer instead of the previously installed OS), if not try to select it manually or remove the previous OS boot entry
+- Check if the servers are booting to the correct OS (Fedora Server installer instead of the previously installed OS), if not try to select it manually or remove the previous OS boot entry

--- a/metal/roles/pxe_server/defaults/main.yml
+++ b/metal/roles/pxe_server/defaults/main.yml
@@ -1,4 +1,4 @@
-iso_url: "https://download.rockylinux.org/pub/rocky/8.6/isos/x86_64/Rocky-8.6-x86_64-minimal.iso"
-iso_checksum: "sha256:a9ece0e810275e881abfd66bb0e59ac05d567a5ec0bc2f108b9a3e90bef5bf94"
+iso_url: "https://download.fedoraproject.org/pub/fedora/linux/releases/36/Server/x86_64/iso/Fedora-Server-dvd-x86_64-36-1.5.iso"
+iso_checksum: "sha256:5edaf708a52687b09f9810c2b6d2a3432edac1b18f4d8c908c0da6bde0379148"
 timezone: Asia/Ho_Chi_Minh
 dhcp_proxy: true

--- a/metal/roles/pxe_server/templates/kickstart.ks.j2
+++ b/metal/roles/pxe_server/templates/kickstart.ks.j2
@@ -19,7 +19,7 @@ partition / --fstype=ext4 --grow
 network --bootproto=static --device={{ hostvars[item]['network_interface'] }} --ip={{ hostvars[item]['ansible_host'] }} --gateway={{ ansible_default_ipv4.gateway }} --nameserver={{ dns_server }} --netmask={{ ansible_default_ipv4.netmask }} --ipv6=auto --hostname={{ hostvars[item]['inventory_hostname'] }} --activate
 
 # Use network installation
-repo --name="Minimal" --baseurl=http://{{ ansible_default_ipv4.address }}/os/Minimal
+repo --name="Repository" --baseurl=http://{{ ansible_default_ipv4.address }}/os
 url --url="http://{{ ansible_default_ipv4.address }}/os"
 # Disable Setup Agent on first boot
 firstboot --disable
@@ -28,7 +28,7 @@ skipx
 # Enable NTP
 services --enabled="chronyd"
 # System timezone
-timezone {{ timezone }} --isUtc
+timezone {{ timezone }} --utc
 
 # Create user (locked by default)
 user --groups=wheel --name=admin
@@ -44,7 +44,8 @@ selinux --disabled
 firewall --disabled
 
 %packages
-@^minimal-environment
+@^custom-environment
+@headless-management
 iscsi-initiator-utils
 %end
 


### PR DESCRIPTION
Because it is the same Red Hat family, the migration is relatively painless.
This change is backward compatible (it doesn't do anything if you don't reinstall), so you can continue to use Rocky Linux if you like. 

Fixes https://github.com/khuedoan/homelab/issues/71.