### PR TITLE
chore(dev): install latest k3d

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ Big shout-out to them!
 - ![](https://github.com/Crimrose.png?size=24) [@Crimrose](https://github.com/Crimrose)
 - ![](https://github.com/eventi.png?size=24) [@eventi](https://github.com/eventi)
 - ![](https://github.com/Bourne-ID.png?size=24) [@Bourne-ID](https://github.com/Bourne-ID)
+- ![](https://github.com/akwan.png?size=24) [@akwan](https://github.com/akwan)
 
 If you feel you're missing from this list, feel free to add yourself in a PR.
 

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -41,9 +41,8 @@ RUN pacman --sync --refresh --noconfirm \
     terraform \
     yamllint
 
-ARG K3D_PATH=/usr/local/bin/k3d
-RUN curl -L https://github.com/k3d-io/k3d/releases/latest/download/k3d-linux-amd64 -o $K3D_PATH -s \
-    && chmod +x $K3D_PATH
+RUN curl -L https://github.com/k3d-io/k3d/releases/latest/download/k3d-linux-amd64 -o /usr/local/bin/k3d -s \
+    && chmod +x /usr/local/bin/k3d
 
 # TODO https://github.com/ansible-collections/community.docker/issues/216
 RUN pip install docker-compose

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -41,9 +41,9 @@ RUN pacman --sync --refresh --noconfirm \
     terraform \
     yamllint
 
-# TODO better way to install k3d?
-RUN curl -L https://github.com/k3d-io/k3d/releases/download/v5.4.1/k3d-linux-amd64 > /usr/local/bin/k3d \
-    && chmod +x /usr/local/bin/k3d
+ARG K3D_PATH=/usr/local/bin/k3d
+RUN curl -L https://github.com/k3d-io/k3d/releases/latest/download/k3d-linux-amd64 -o $K3D_PATH -s \
+    && chmod +x $K3D_PATH
 
 # TODO https://github.com/ansible-collections/community.docker/issues/216
 RUN pip install docker-compose


### PR DESCRIPTION
If you want to fetch the latest `k3d` whenever building the homelab-tools docker image. Inspired from https://gist.github.com/steinwaywhw/a4cd19cda655b8249d908261a62687f8
