### PR TITLE
Allow other architecture hosts

### DIFF
--- a/metal/roles/k3s/defaults/main.yml
+++ b/metal/roles/k3s/defaults/main.yml
@@ -1,4 +1,13 @@
 k3s_version: v1.28.3+k3s2
+
+k3s_architectures:
+  x86_64:
+    arch_suffix: ""
+    arch_sum: sha256sum-amd64.txt
+  aarch64:
+    arch_suffix: "-arm64"
+    arch_sum: sha256sum-arm64.txt
+
 k3s_config_file: /etc/rancher/k3s/config.yaml
 k3s_token_file: /etc/rancher/node/password
 k3s_service_file: /etc/systemd/system/k3s.service

--- a/metal/roles/k3s/tasks/main.yml
+++ b/metal/roles/k3s/tasks/main.yml
@@ -1,16 +1,17 @@
 - name: Download k3s binary
   ansible.builtin.get_url:
-    url: https://github.com/k3s-io/k3s/releases/download/{{ k3s_version }}/k3s
-    checksum: sha256:https://github.com/k3s-io/k3s/releases/download/{{ k3s_version }}/sha256sum-amd64.txt
-    dest: "{{ role_path }}/files/bin/k3s"
+    url: https://github.com/k3s-io/k3s/releases/download/{{ k3s_version }}/k3s{{ k3s_architectures[item].arch_suffix }}
+    checksum: sha256:https://github.com/k3s-io/k3s/releases/download/{{ k3s_version }}/{{ k3s_architectures[item].arch_sum }}
+    dest: "{{ role_path }}/files/bin/k3s{{ k3s_architectures[item].arch_suffix }}"
     mode: 0755
   delegate_to: localhost
   run_once: true
   register: k3s_binary
+  loop: "{{ k3s_architectures.keys() | list }}"
 
 - name: Copy k3s binary to nodes
   ansible.builtin.copy:
-    src: bin/k3s
+    src: bin/k3s{{ k3s_architectures[ansible_architecture].arch_suffix }}
     dest: /usr/local/bin/k3s
     owner: root
     group: root


### PR DESCRIPTION
This add support for arm64 (which shows up in ansible as aarch64).

To add another, add something like this to k3s_architectures:

```
  <ansible_architecture output>:
    arch_suffix: "<suffix of binary on k3s releases>"
    arch_sum: "<name of file that contains the checksums for arch>"
```

Tested with a raspberry pi running debian aarch64 upstream.