### PR TITLE
feat(flake.nix): Switch to OpenTofu

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -40,10 +40,10 @@
             libisoburn
             neovim
             openssh
+            opentofu
             p7zip
             pre-commit
             shellcheck
-            opentofu
             yamllint
 
             (python3.withPackages (p: with p; [

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,6 @@
         # (Source: https://xeiaso.net/blog/notes/nix-flakes-terraform-unfree-fix)
         pkgs = import nixpkgs {
           inherit system;
-          config.allowUnfree = true;
         };
       in
       with pkgs;
@@ -44,7 +43,7 @@
             p7zip
             pre-commit
             shellcheck
-            terraform # TODO replace with OpenTofu, Terraform is no longer FOSS
+            opentofu
             yamllint
 
             (python3.withPackages (p: with p; [


### PR DESCRIPTION
## Intent

- Address #156 
- Terragrunt supports OpenTofu by default in v0.52.0 (`terraform` will fallback to `tofu` if needed) and /nixpkgs/nixos-23.11 has the `0.53.4` version so it looks good to bump this
- Cleaning up the `config.allowUnfree = true;` as well