### PR TITLE
set loki image tag to version 2.8.6

### DIFF
--- a/system/loki/values.yaml
+++ b/system/loki/values.yaml
@@ -2,3 +2,5 @@ loki-stack:
   loki:
     serviceMonitor:
       enabled: true
+    image:
+      tag: 2.8.6


### PR DESCRIPTION
default loki version of this helm chart is not adaptable for grafana chart  7.3.3