### PR TITLE
Install glibcLocales to fix 'cannot change locale' error

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -23,6 +23,7 @@
             docker-compose
             dyff
             git
+            glibcLocales
             go
             gotestsum
             iproute2


### PR DESCRIPTION
Had the same issue as described in #163 and this fixed it for me on Ubuntu 22.04.