### PR TITLE
fix: replace openssh with openssh_gssapi

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -36,7 +36,7 @@
             kustomize
             libisoburn
             neovim
-            openssh
+            openssh_gssapi
             opentofu # Drop-in replacement for Terraform
             p7zip
             pre-commit


### PR DESCRIPTION
Default `openssh` doesn't provide support for `gssapikexalgorithms` and fails with following on Fedora server 42
```console 

Failed to connect to the host via ssh: /etc/crypto-policies/back-ends/openssh.config: line 3: Bad configuration option: gssapikexalgorithms
/etc/crypto-policies/back-ends/openssh.config: terminating, 1 bad configuration options
fatal: [metal1]: UNREACHABLE! => {
    "changed": false,
    "unreachable": true
}
````

 Replacing package with `openssh_gssapi` resolves this error