### PR TITLE
Add headscale support

### DIFF
--- a/apps/tailscale/values.yaml
+++ b/apps/tailscale/values.yaml
@@ -18,6 +18,7 @@ app-template:
                 secretKeyRef:
                   name: tailscale-auth
                   key: TS_AUTHKEY
+            TS_EXTRA_ARGS: "--login-server https://headscale.khuedoan.com --advertise-tags=tag:server"
           securityContext:
             capabilities:
               add:

--- a/platform/dex/templates/secret.yaml
+++ b/platform/dex/templates/secret.yaml
@@ -28,3 +28,7 @@ spec:
       remoteRef:
         key: dex.gitea
         property: client_secret
+    - secretKey: HEADSCALE_CLIENT_SECRET
+      remoteRef:
+        key: dex.headscale
+        property: client_secret

--- a/platform/dex/values.yaml
+++ b/platform/dex/values.yaml
@@ -34,6 +34,11 @@ dex:
         redirectURIs:
           - 'https://git.khuedoan.com/user/oauth2/Dex/callback'
         secretEnv: GITEA_CLIENT_SECRET
+      - id: headscale
+        name: Headscale
+        redirectURIs:
+          - 'https://headscale.khuedoan.com/oidc/callback'
+        secretEnv: HEADSCALE_CLIENT_SECRET
   envFrom:
     - secretRef:
         name: dex-secrets

--- a/platform/global-secrets/files/secret-generator/config.yaml
+++ b/platform/global-secrets/files/secret-generator/config.yaml
@@ -16,6 +16,11 @@
     - key: client_secret
       length: 32
       special: false
+- name: dex.headscale
+  data:
+    - key: client_secret
+      length: 32
+      special: false
 
 # Registry
 - name: registry.admin

--- a/platform/headscale/Chart.yaml
+++ b/platform/headscale/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: headscale
+version: 0.0.0
+dependencies:
+  - name: app-template
+    version: 4.1.1
+    repository: https://bjw-s-labs.github.io/helm-charts

--- a/platform/headscale/configs/acl-policy.hujson
+++ b/platform/headscale/configs/acl-policy.hujson
@@ -1,0 +1,31 @@
+{
+    "tagOwners": {
+        "tag:server": [],
+    },
+    // Allow all connections to server machines
+    "acls": [
+        {
+            "action": "accept",
+            "src": [
+                "*"
+            ],
+            "dst": [
+                "tag:server:*"
+            ],
+        }
+    ],
+    "ssh": [
+        {
+            "action": "accept",
+            "src": [
+                "*"
+            ],
+            "dst": [
+                "tag:server"
+            ],
+            "users": [
+                "root",
+            ]
+        }
+    ]
+}

--- a/platform/headscale/configs/config.yaml
+++ b/platform/headscale/configs/config.yaml
@@ -1,0 +1,366 @@
+---
+# headscale will look for a configuration file named `config.yaml` (or `config.json`) in the following order:
+#
+# - `/etc/headscale`
+# - `~/.headscale`
+# - current working directory
+
+# The url clients will connect to.
+# Typically this will be a domain like:
+#
+# https://myheadscale.example.com:443
+#
+# Configured by env var
+# server_url: http://127.0.0.1:8080
+
+# Address to listen to / bind to on the server
+#
+# For production:
+listen_addr: 0.0.0.0:8080
+# listen_addr: 127.0.0.1:8080
+
+# Address to listen to /metrics and /debug, you may want
+# to keep this endpoint private to your internal network
+metrics_listen_addr: 0.0.0.0:9090
+
+# Address to listen for gRPC.
+# gRPC is used for controlling a headscale server
+# remotely with the CLI
+# Note: Remote access _only_ works if you have
+# valid certificates.
+#
+# For production:
+grpc_listen_addr: 0.0.0.0:50443
+# grpc_listen_addr: 127.0.0.1:50443
+
+# Allow the gRPC admin interface to run in INSECURE
+# mode. This is not recommended as the traffic will
+# be unencrypted. Only enable if you know what you
+# are doing.
+grpc_allow_insecure: false
+
+# The Noise section includes specific configuration for the
+# TS2021 Noise protocol
+noise:
+  # The Noise private key is used to encrypt the traffic between headscale and
+  # Tailscale clients when using the new Noise-based protocol. A missing key
+  # will be automatically generated.
+  private_key_path: /var/lib/headscale/noise_private.key
+
+# List of IP prefixes to allocate tailaddresses from.
+# Each prefix consists of either an IPv4 or IPv6 address,
+# and the associated prefix length, delimited by a slash.
+# It must be within IP ranges supported by the Tailscale
+# client - i.e., subnets of 100.64.0.0/10 and fd7a:115c:a1e0::/48.
+# See below:
+# IPv6: https://github.com/tailscale/tailscale/blob/22ebb25e833264f58d7c3f534a8b166894a89536/net/tsaddr/tsaddr.go#LL81C52-L81C71
+# IPv4: https://github.com/tailscale/tailscale/blob/22ebb25e833264f58d7c3f534a8b166894a89536/net/tsaddr/tsaddr.go#L33
+# Any other range is NOT supported, and it will cause unexpected issues.
+prefixes:
+  v4: 100.64.0.0/10
+  v6: fd7a:115c:a1e0::/48
+
+  # Strategy used for allocation of IPs to nodes, available options:
+  # - sequential (default): assigns the next free IP from the previous given IP.
+  # - random: assigns the next free IP from a pseudo-random IP generator (crypto/rand).
+  allocation: sequential
+
+# DERP is a relay system that Tailscale uses when a direct
+# connection cannot be established.
+# https://tailscale.com/blog/how-tailscale-works/#encrypted-tcp-relays-derp
+#
+# headscale needs a list of DERP servers that can be presented
+# to the clients.
+derp:
+  server:
+    # If enabled, runs the embedded DERP server and merges it into the rest of the DERP config
+    # The Headscale server_url defined above MUST be using https, DERP requires TLS to be in place
+    enabled: false
+
+    # Region ID to use for the embedded DERP server.
+    # The local DERP prevails if the region ID collides with other region ID coming from
+    # the regular DERP config.
+    region_id: 999
+
+    # Region code and name are displayed in the Tailscale UI to identify a DERP region
+    region_code: "headscale"
+    region_name: "Headscale Embedded DERP"
+
+    # Only allow clients associated with this server access
+    verify_clients: true
+
+    # Listens over UDP at the configured address for STUN connections - to help with NAT traversal.
+    # When the embedded DERP server is enabled stun_listen_addr MUST be defined.
+    #
+    # For more details on how this works, check this great article: https://tailscale.com/blog/how-tailscale-works/
+    stun_listen_addr: "0.0.0.0:3478"
+
+    # Private key used to encrypt the traffic between headscale DERP and
+    # Tailscale clients. A missing key will be automatically generated.
+    private_key_path: /var/lib/headscale/derp_server_private.key
+
+    # This flag can be used, so the DERP map entry for the embedded DERP server is not written automatically,
+    # it enables the creation of your very own DERP map entry using a locally available file with the parameter DERP.paths
+    # If you enable the DERP server and set this to false, it is required to add the DERP server to the DERP map using DERP.paths
+    automatically_add_embedded_derp_region: true
+
+    # For better connection stability (especially when using an Exit-Node and DNS is not working),
+    # it is possible to optionally add the public IPv4 and IPv6 address to the Derp-Map using:
+    ipv4: 1.2.3.4
+    ipv6: 2001:db8::1
+
+  # List of externally available DERP maps encoded in JSON
+  urls:
+    - https://controlplane.tailscale.com/derpmap/default
+
+  # Locally available DERP map files encoded in YAML
+  #
+  # This option is mostly interesting for people hosting
+  # their own DERP servers:
+  # https://tailscale.com/kb/1118/custom-derp-servers/
+  #
+  # paths:
+  #   - /etc/headscale/derp-example.yaml
+  paths: []
+
+  # If enabled, a worker will be set up to periodically
+  # refresh the given sources and update the derpmap
+  # will be set up.
+  auto_update_enabled: true
+
+  # How often should we check for DERP updates?
+  update_frequency: 24h
+
+# Disables the automatic check for headscale updates on startup
+disable_check_updates: false
+
+# Time before an inactive ephemeral node is deleted?
+ephemeral_node_inactivity_timeout: 30m
+
+database:
+  # Database type. Available options: sqlite, postgres
+  # Please note that using Postgres is highly discouraged as it is only supported for legacy reasons.
+  # All new development, testing and optimisations are done with SQLite in mind.
+  type: sqlite
+
+  # Enable debug mode. This setting requires the log.level to be set to "debug" or "trace".
+  debug: false
+
+  # GORM configuration settings.
+  gorm:
+    # Enable prepared statements.
+    prepare_stmt: true
+
+    # Enable parameterized queries.
+    parameterized_queries: true
+
+    # Skip logging "record not found" errors.
+    skip_err_record_not_found: true
+
+    # Threshold for slow queries in milliseconds.
+    slow_threshold: 1000
+
+  # SQLite config
+  sqlite:
+    path: /var/lib/headscale/db.sqlite
+
+    # Enable WAL mode for SQLite. This is recommended for production environments.
+    # https://www.sqlite.org/wal.html
+    write_ahead_log: true
+
+    # Maximum number of WAL file frames before the WAL file is automatically checkpointed.
+    # https://www.sqlite.org/c3ref/wal_autocheckpoint.html
+    # Set to 0 to disable automatic checkpointing.
+    wal_autocheckpoint: 1000
+
+  # # Postgres config
+  # Please note that using Postgres is highly discouraged as it is only supported for legacy reasons.
+  # See database.type for more information.
+  # postgres:
+  #   # If using a Unix socket to connect to Postgres, set the socket path in the 'host' field and leave 'port' blank.
+  #   host: localhost
+  #   port: 5432
+  #   name: headscale
+  #   user: foo
+  #   pass: bar
+  #   max_open_conns: 10
+  #   max_idle_conns: 10
+  #   conn_max_idle_time_secs: 3600
+
+  #   # If other 'sslmode' is required instead of 'require(true)' and 'disabled(false)', set the 'sslmode' you need
+  #   # in the 'ssl' field. Refers to https://www.postgresql.org/docs/current/libpq-ssl.html Table 34.1.
+  #   ssl: false
+
+### TLS configuration
+## Use already defined certificates:
+tls_cert_path: /tls/tls.crt
+tls_key_path: /tls/tls.key
+
+log:
+  # Output formatting for logs: text or json
+  format: text
+  level: trace
+
+## Policy
+# headscale supports Tailscale's ACL policies.
+# Please have a look to their KB to better
+# understand the concepts: https://tailscale.com/kb/1018/acls/
+policy:
+  # The mode can be "file" or "database" that defines
+  # where the ACL policies are stored and read from.
+  mode: file
+  # If the mode is set to "file", the path to a
+  # HuJSON file containing ACL policies.
+  path: /etc/headscale/acl-policy.hujson
+
+## DNS
+#
+# headscale supports Tailscale's DNS configuration and MagicDNS.
+# Please have a look to their KB to better understand the concepts:
+#
+# - https://tailscale.com/kb/1054/dns/
+# - https://tailscale.com/kb/1081/magicdns/
+# - https://tailscale.com/blog/2021-09-private-dns-with-magicdns/
+#
+# Please note that for the DNS configuration to have any effect,
+# clients must have the `--accept-dns=true` option enabled. This is the
+# default for the Tailscale client. This option is enabled by default
+# in the Tailscale client.
+#
+# Setting _any_ of the configuration and `--accept-dns=true` on the
+# clients will integrate with the DNS manager on the client or
+# overwrite /etc/resolv.conf.
+# https://tailscale.com/kb/1235/resolv-conf
+#
+# If you want stop Headscale from managing the DNS configuration
+# all the fields under `dns` should be set to empty values.
+dns:
+  # Whether to use [MagicDNS](https://tailscale.com/kb/1081/magicdns/).
+  magic_dns: true
+
+  # Defines the base domain to create the hostnames for MagicDNS.
+  # This domain _must_ be different from the server_url domain.
+  # `base_domain` must be a FQDN, without the trailing dot.
+  # The FQDN of the hosts will be
+  # `hostname.base_domain` (e.g., _myhost.example.com_).
+  base_domain: example.com
+
+  # Whether to use the local DNS settings of a node (default) or override the
+  # local DNS settings and force the use of Headscale's DNS configuration.
+  override_local_dns: false
+
+  # List of DNS servers to expose to clients.
+  nameservers:
+    global:
+      - 1.1.1.1
+      - 1.0.0.1
+      - 2606:4700:4700::1111
+      - 2606:4700:4700::1001
+
+      # NextDNS (see https://tailscale.com/kb/1218/nextdns/).
+      # "abc123" is example NextDNS ID, replace with yours.
+      # - https://dns.nextdns.io/abc123
+
+    # Split DNS (see https://tailscale.com/kb/1054/dns/),
+    # a map of domains and which DNS server to use for each.
+    split:
+      {}
+      # foo.bar.com:
+      #   - 1.1.1.1
+      # darp.headscale.net:
+      #   - 1.1.1.1
+      #   - 8.8.8.8
+
+  # Set custom DNS search domains. With MagicDNS enabled,
+  # your tailnet base_domain is always the first search domain.
+  search_domains: []
+
+  # Extra DNS records
+  # so far only A and AAAA records are supported (on the tailscale side)
+  # See: docs/ref/dns.md
+  extra_records: []
+  #   - name: "grafana.myvpn.example.com"
+  #     type: "A"
+  #     value: "100.64.0.3"
+  #
+  #   # you can also put it in one line
+  #   - { name: "prometheus.myvpn.example.com", type: "A", value: "100.64.0.3" }
+  #
+  # Alternatively, extra DNS records can be loaded from a JSON file.
+  # Headscale processes this file on each change.
+  # extra_records_path: /var/lib/headscale/extra-records.json
+
+# Unix socket used for the CLI to connect without authentication
+# Note: for production you will want to set this to something like:
+unix_socket: /var/run/headscale/headscale.sock
+unix_socket_permission: "0770"
+#
+# headscale supports experimental OpenID connect support,
+# it is still being tested and might have some bugs, please
+# help us test it.
+# OpenID Connect
+oidc:
+  only_start_if_oidc_is_available: true
+  issuer: "https://dex.khuedoan.com"
+  client_id: "headscale"
+  # client_secret: "your-oidc-client-secret"
+  # Alternatively, set `client_secret_path` to read the secret from the file.
+  # It resolves environment variables, making integration to systemd's
+  # `LoadCredential` straightforward:
+  client_secret_path: "/oidc/oidc_client_secret"
+  # client_secret and client_secret_path are mutually exclusive.
+
+  # The amount of time from a node is authenticated with OpenID until it
+  # expires and needs to reauthenticate.
+  # Setting the value to "0" will mean no expiry.
+  expiry: 0
+
+  # Use the expiry from the token received from OpenID when the user logged
+  # in, this will typically lead to frequent need to reauthenticate and should
+  # only been enabled if you know what you are doing.
+  # Note: enabling this will cause `oidc.expiry` to be ignored.
+  # use_expiry_from_token: false
+
+  # Customize the scopes used in the OIDC flow, defaults to "openid", "profile" and "email" and add custom query
+  # parameters to the Authorize Endpoint request. Scopes default to "openid", "profile" and "email".
+
+  scope: ["openid", "profile", "email", "groups"]
+  extra_params:
+    domain_hint: auth.khuedoan.com
+
+  # List allowed principal domains and/or users. If an authenticated user's domain is not in this list, the
+  # authentication request will be rejected.
+
+  # allowed_domains:
+  #   - example.com
+  # # Note: Groups from keycloak have a leading '/'
+  # allowed_groups:
+  #   - /headscale
+  # allowed_users:
+  #   - alice@example.com
+
+  # Optional: PKCE (Proof Key for Code Exchange) configuration
+  # PKCE adds an additional layer of security to the OAuth 2.0 authorization code flow
+  # by preventing authorization code interception attacks
+  # See https://datatracker.ietf.org/doc/html/rfc7636
+  pkce:
+    # Enable or disable PKCE support (default: false)
+    enabled: false
+    # PKCE method to use:
+    # - plain: Use plain code verifier
+    # - S256: Use SHA256 hashed code verifier (default, recommended)
+    method: S256
+
+# Logtail configuration
+# Logtail is Tailscales logging and auditing infrastructure, it allows the control panel
+# to instruct tailscale nodes to log their activity to a remote server.
+logtail:
+  # Enable logtail for this headscales clients.
+  # As there is currently no support for overriding the log server in headscale, this is
+  # disabled by default. Enabling this will make your clients send logs to Tailscale Inc.
+  enabled: false
+
+# Enabling this option makes devices prefer a random port for WireGuard traffic over the
+# default static port 41641. This option is intended as a workaround for some buggy
+# firewall devices. See https://tailscale.com/kb/1181/firewalls/ for more information.
+randomize_client_port: false

--- a/platform/headscale/configs/headplane.yaml
+++ b/platform/headscale/configs/headplane.yaml
@@ -1,0 +1,159 @@
+# Configuration for the Headplane server and web application
+server:
+  host: "0.0.0.0"
+  port: 3000
+
+  # The secret used to encode and decode web sessions
+  # Ensure that this is exactly 32 characters long
+  cookie_secret: <your-cookie-secret>
+
+  # Should the cookies only work over HTTPS?
+  # Set to false if running via HTTP without a proxy
+  # (I recommend this is true in production)
+  cookie_secure: true
+
+# Headscale specific settings to allow Headplane to talk
+# to Headscale and access deep integration features
+headscale:
+  # The URL to your Headscale instance
+  # (All API requests are routed through this URL)
+  # (THIS IS NOT the gRPC endpoint, but the HTTP endpoint)
+  #
+  # IMPORTANT: If you are using TLS this MUST be set to `https://`
+  url: "https://headscale.khuedoan.com"
+
+  # If you use the TLS configuration in Headscale, and you are not using
+  # Let's Encrypt for your certificate, pass in the path to the certificate.
+  # (This has no effect `url` does not start with `https://`)
+  # tls_cert_path: "/tls/tls.crt"
+
+  # Optional, public URL if they differ
+  # This affects certain parts of the web UI
+  public_url: "https://headscale.khuedoan.com"
+
+  # Path to the Headscale configuration file
+  # This is optional, but HIGHLY recommended for the best experience
+  # If this is read only, Headplane will show your configuration settings
+  # in the Web UI, but they cannot be changed.
+  config_path: "/etc/headscale/config.yaml"
+
+  # Headplane internally validates the Headscale configuration
+  # to ensure that it changes the configuration in a safe way.
+  # If you want to disable this validation, set this to false.
+  config_strict: true
+
+  # If you are using `dns.extra_records_path` in your Headscale
+  # configuration, you need to set this to the path for Headplane
+  # to be able to read the DNS records.
+  #
+  # Pass it in if using Docker and ensure that the file is both
+  # readable and writable to the Headplane process.
+  # When using this, Headplane will no longer need to automatically
+  # restart Headscale for DNS record changes.
+  # dns_records_path: "/var/lib/headplane/extra_records.json"
+
+# Integration configurations for Headplane to interact with Headscale
+integration:
+  agent:
+    # The Headplane agent allows retrieving information about nodes
+    # This allows the UI to display version, OS, and connectivity data
+    # You will see the Headplane agent in your Tailnet as a node when
+    # it connects.
+    enabled: false
+    # To connect to your Tailnet, you need to generate a pre-auth key
+    # This can be done via the web UI or through the `headscale` CLI.
+    pre_authkey: "<your-preauth-key>"
+    # Optionally change the name of the agent in the Tailnet.
+    # host_name: "headplane-agent"
+
+    # Configure different caching settings. By default, the agent will store
+    # caches in the path below for a maximum of 1 minute. If you want data
+    # to update faster, reduce the TTL, but this will increase the frequency
+    # of requests to Headscale.
+    # cache_ttl: 60
+    # cache_path: /var/lib/headplane/agent_cache.json
+
+    # Do not change this unless you are running a custom deployment.
+    # The work_dir represents where the agent will store its data to be able
+    # to automatically reauthenticate with your Tailnet. It needs to be
+    # writable by the user running the Headplane process.
+    # work_dir: "/var/lib/headplane/agent"
+
+  # Only one of these should be enabled at a time or you will get errors
+  # This does not include the agent integration (above), which can be enabled
+  # at the same time as any of these and is recommended for the best experience.
+  docker:
+    enabled: false
+
+    # By default we check for the presence of a container label (see the docs)
+    # to determine the container to signal when changes are made to DNS settings.
+    container_label: "me.tale.headplane.target=headscale"
+
+    # HOWEVER, you can fallback to a container name if you desire, but this is
+    # not recommended as its brittle and doesn't work with orchestrators that
+    # automatically assign container names.
+    #
+    # If `container_name` is set, it will override any label checks.
+    # container_name: "headscale"
+
+    # The path to the Docker socket (do not change this if you are unsure)
+    # Docker socket paths must start with unix:// or tcp:// and at the moment
+    # https connections are not supported.
+    socket: "unix:///var/run/docker.sock"
+
+  # Please refer to docs/integration/Kubernetes.md for more information
+  # on how to configure the Kubernetes integration. There are requirements in
+  # order to allow Headscale to be controlled by Headplane in a cluster.
+  kubernetes:
+    enabled: true
+    # Validates the manifest for the Pod to ensure all of the criteria
+    # are set correctly. Turn this off if you are having issues with
+    # shareProcessNamespace not being validated correctly.
+    validate_manifest: true
+    # This should be the name of the Pod running Headscale and Headplane.
+    # If this isn't static you should be using the Kubernetes Downward API
+    # to set this value (refer to docs/Integrated-Mode.md for more info).
+    pod_name: "headscale"
+
+  # Proc is the "Native" integration that only works when Headscale and
+  # Headplane are running outside of a container. There is no configuration,
+  # but you need to ensure that the Headplane process can terminate the
+  # Headscale process.
+  #
+  # (If they are both running under systemd as sudo, this will work).
+  proc:
+    enabled: false
+
+# OIDC Configuration for simpler authentication
+# (This is optional, but recommended for the best experience)
+# oidc:
+#   issuer: "https://accounts.google.com"
+#   client_id: "your-client-id"
+
+#   # The client secret for the OIDC client
+#   # Either this or `client_secret_path` must be set for OIDC to work
+#   client_secret: "<your-client-secret>"
+#   # You can alternatively set `client_secret_path` to read the secret from disk.
+#   # The path specified can resolve environment variables, making integration
+#   # with systemd's `LoadCredential` straightforward:
+#   # client_secret_path: "${CREDENTIALS_DIRECTORY}/oidc_client_secret"
+
+#   disable_api_key_login: false
+#   token_endpoint_auth_method: "client_secret_post"
+
+#   # If you are using OIDC, you need to generate an API key
+#   # that can be used to authenticate other sessions when signing in.
+#   #
+#   # This can be done with `headscale apikeys create --expiration 999d`
+#   headscale_api_key: "<your-headscale-api-key>"
+
+#   # Optional, but highly recommended otherwise Headplane
+#   # will attempt to automatically guess this from the issuer
+#   #
+#   # This should point to your publicly accessibly URL
+#   # for your Headplane instance with /admin/oidc/callback
+#   redirect_uri: "http://localhost:3000/admin/oidc/callback"
+
+#   # Stores the users and their permissions for Headplane
+#   # This is a path to a JSON file, default is specified below.
+#   user_storage_file: "/var/lib/headplane/users.json"

--- a/platform/headscale/templates/headplane-config.yaml
+++ b/platform/headscale/templates/headplane-config.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: headplane-config
+data:
+{{ (.Files.Glob "configs/headplane.yaml").AsConfig | indent 2 }}

--- a/platform/headscale/templates/headplane-cookie-secret.yaml
+++ b/platform/headscale/templates/headplane-cookie-secret.yaml
@@ -1,0 +1,15 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: headplane-cookie
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: global-secrets
+  target:
+    name: headplane-cookie
+  data:
+    - secretKey: oidc_client_secret
+      remoteRef:
+        key: headplane.cookie
+        property: cookie_secret

--- a/platform/headscale/templates/headscale-acl-policy.yaml
+++ b/platform/headscale/templates/headscale-acl-policy.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: headscale-acl-policy
+data:
+{{ (.Files.Glob "configs/acl-policy.hujson").AsConfig | indent 2 }}

--- a/platform/headscale/templates/headscale-config.yaml
+++ b/platform/headscale/templates/headscale-config.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: headscale-config
+data:
+{{ (.Files.Glob "configs/config.yaml").AsConfig | indent 2 }}

--- a/platform/headscale/templates/oidc-secret.yaml
+++ b/platform/headscale/templates/oidc-secret.yaml
@@ -1,0 +1,16 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: headscale-secret
+  namespace: {{ .Release.Namespace }}
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: global-secrets
+  target:
+    name: headscale-secret
+  data:
+    - secretKey: oidc_client_secret
+      remoteRef:
+        key: dex.headscale
+        property: client_secret

--- a/platform/headscale/templates/role.yaml
+++ b/platform/headscale/templates/role.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: headplane-agent
+rules:
+- apiGroups: ['']
+  resources: ['pods']
+  verbs: ['get', 'list']
+- apiGroups: ['apps']
+  resources: ['deployments']
+  verbs: ['get', 'list']

--- a/platform/headscale/templates/rolebinding.yaml
+++ b/platform/headscale/templates/rolebinding.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: headplane-agent
+roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: headplane-agent
+subjects:
+- kind: ServiceAccount
+  name: headplane

--- a/platform/headscale/templates/serviceaccount.yaml
+++ b/platform/headscale/templates/serviceaccount.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: headplane

--- a/platform/headscale/values.yaml
+++ b/platform/headscale/values.yaml
@@ -1,0 +1,161 @@
+app-template:
+  defaultPodOptions:
+    shareProcessNamespace: true
+  controllers:
+    headscale:
+      serviceAccount:
+        name: headplane
+      containers:
+        headscale:
+          image:
+            repository: headscale/headscale
+            tag: v0.26.1
+          args:
+            - serve
+          env:
+            - name: HEADSCALE_SERVER_URL
+              value: https://headscale.khuedoan.com
+            - name: HEADSCALE_DNS_BASE_DOMAIN
+              value: hs-machine.khuedoan.com
+        headplane:
+          image:
+            repository: ghcr.io/tale/headplane
+            tag: 0.6.0
+          env:
+            - name: HEADPLANE_LOAD_ENV_OVERRIDES
+              value: 'true'
+            - name: 'HEADPLANE_INTEGRATION__KUBERNETES__POD_NAME'
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+  service:
+    headscale:
+      controller: headscale
+      ports:
+        http:
+          port: 8080
+          protocol: HTTP
+        headplane:
+          port: 3000
+          protocol: HTTP
+        metrics:
+          port: 9090
+          protocol: TCP
+        grpc:
+          port: 50443
+          protocol: TCP
+  ingress:
+    headscale:
+      enabled: true
+      className: nginx
+      annotations:
+        external-dns.alpha.kubernetes.io/target: ddns.khuedoan.com
+        cert-manager.io/cluster-issuer: letsencrypt-prod
+        nginx.ingress.kubernetes.io/ssl-passthrough: "true"
+        nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+      hosts:
+        - host: &host headscale.khuedoan.com
+          paths:
+            - path: /
+              pathType: Prefix
+              service:
+                identifier: headscale
+                port: http
+      tls:
+        - hosts:
+            - *host
+          secretName: headscale-tls-certificate
+    headplane:
+      enabled: true
+      className: nginx
+      annotations:
+        cert-manager.io/cluster-issuer: letsencrypt-prod
+      hosts:
+        - host: &host hs-admin.khuedoan.com
+          paths:
+            - path: /
+              pathType: Prefix
+              service:
+                identifier: headscale
+                port: headplane
+      tls:
+        - hosts:
+            - *host
+          secretName: hs-admin-tls-certificate
+    grpc:
+      enabled: true
+      className: nginx
+      annotations:
+        external-dns.alpha.kubernetes.io/target: ddns.khuedoan.com
+        cert-manager.io/cluster-issuer: letsencrypt-prod
+        nginx.ingress.kubernetes.io/ssl-passthrough: "true"
+        nginx.ingress.kubernetes.io/backend-protocol: "GRPCS"
+      hosts:
+        - host: &host-grpc hs-grpc.khuedoan.com
+          paths:
+            - path: /
+              pathType: Prefix
+              service:
+                identifier: headscale
+                port: grpc
+      tls:
+        - hosts:
+            - *host-grpc
+          secretName: hs-grpc-tls-certificate
+  persistence:
+    config:
+      type: configMap
+      name: headscale-config
+      globalMounts:
+        - path: /etc/headscale/config.yaml
+          subPath: config.yaml
+          readOnly: true
+    headplane-config:
+      type: configMap
+      name: headplane-config
+      globalMounts:
+        - path: /etc/headplane/config.yaml
+          subPath: headplane.yaml
+          readOnly: true
+    acl-policy:
+      type: configMap
+      name: headscale-acl-policy
+      globalMounts:
+        - path: /etc/headscale/acl-policy.hujson
+          subPath: acl-policy.hujson
+          readOnly: true
+    tls:
+      type: secret
+      name: headscale-tls-certificate
+      globalMounts:
+        - path: /tls
+          readOnly: true
+    oidc:
+      type: secret
+      name: headscale-secret
+      globalMounts:
+        - path: /oidc
+          readOnly: true
+    headplane-cookie:
+      type: secret
+      name: headplane-cookie
+      globalMounts:
+        - path: /cookie
+          subPath: cookie
+          readOnly: true
+    volume:
+      accessMode: ReadWriteOnce
+      size: 10Gi
+      globalMounts:
+        - path: /etc/headscale
+          subPath: etc
+        - path: /var/lib/headscale
+          subPath: lib
+        - path: /var/run/headscale
+          subPath: run
+        - path: /etc/headplane
+          subPath: hp-etc
+        - path: /var/lib/headplane
+          subPath: hp-lib
+        - path: /var/run/headplane
+          subPath: hp-run


### PR DESCRIPTION
Hello!
I managed to get [headscale](https://headscale.net/stable/), an opensource alternative to Tailscale, running on my own homelab. I found it much easier to use than plain wireguard. My homelab repo is private and I changed a lot of things, so I thought I'd start a draft PR here for you to take a look and see if this interests you. You're welcome to take over the PR or provide directions to improve it. I'm also happy to just update the docs to say this is an option if you do not feel ready to play around with this.

Notes:
*  This modifies the tailscale container to connect to headscale, I haven't tried to make it work with both headscale and the original tailscale, but I beleive it is possible with some tweaking.
* Headscale didn't work for me behind a cloudflare tunnel, so I ran it with port forwarding and ddns.