### PR TITLE
fix: update PXE server defaults for Fedora 39

### DIFF
--- a/metal/roles/pxe_server/defaults/main.yml
+++ b/metal/roles/pxe_server/defaults/main.yml
@@ -1,4 +1,4 @@
-iso_url: "https://download.fedoraproject.org/pub/fedora/linux/releases/39/Server/x86_64/iso/Fedora-Server-dvd-x86_64-39-1.5.iso"
+iso_url: "https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/39/Server/x86_64/iso/Fedora-Server-dvd-x86_64-39-1.5.iso"
 iso_checksum: "sha256:2755cdff6ac6365c75be60334bf1935ade838fc18de53d4c640a13d3e904f6e9"
 timezone: Asia/Ho_Chi_Minh
 dhcp_proxy: true


### PR DESCRIPTION
As disccused under issue [194](https://github.com/khuedoan/homelab/issues/194), this PR updates the source for Fedora 39 to pull from the Fedora archives, preventing failure during the PXE provisioning process.

Checksum remains the same, only the source URL for the ISO image has changed.